### PR TITLE
Potential fix for code scanning alert no. 10: Incomplete multi-character sanitization

### DIFF
--- a/Komo-live-chat/js/index.js
+++ b/Komo-live-chat/js/index.js
@@ -6,6 +6,16 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
 
 (function () {
 
+    // Helper function to repeatedly remove HTML tags for robust sanitization.
+    function stripHtmlTags(input) {
+        var previous;
+        do {
+            previous = input;
+            input = input.replace(/<[^>]+>/g, "");
+        } while (input !== previous);
+        return input;
+    }
+
     var AUTHOR = {
         AUTHOR: 'author',
         ME: 'me'
@@ -92,7 +102,7 @@ function _toConsumableArray(arr) { if (Array.isArray(arr)) { for (var i = 0, arr
                 var _this3 = this;
 
                 var content = getRandomMsg(message);
-                var length = content.replace(/<[^>]+>/g, "").length;
+                var length = stripHtmlTags(content).length;
                 var isImg = /<img[^>]+>/.test(content);
                 var isTyping = length > 2 || isImg;
 


### PR DESCRIPTION
Potential fix for [https://github.com/ktwu01/komo520/security/code-scanning/10](https://github.com/ktwu01/komo520/security/code-scanning/10)

The best way to fix this issue is to switch from using a naive regular expression to a well-tested sanitization library, such as [sanitize-html](https://www.npmjs.com/package/sanitize-html), which is designed to robustly remove unsafe HTML, including scripts and other potentially harmful content. If adding a dependency is not possible, a safe fallback is to repeatedly apply the regex replacement until no more tags are found, or to use a more robust approach such as removing all `<` and `>` characters, though this is more destructive and may strip safe content.

Given the constraints (only edit within the file and code you've been shown), and to avoid changing existing functionality, the most robust fix here is to repeatedly apply the regex replacement in a loop until no further changes are made, as suggested in the background section. This ensures all HTML tags—regardless of how they're nested or split—are fully removed. This can be encapsulated in a helper function, e.g., `stripHtmlTags`, defined in the same file, and replace the direct `replace` call with a call to this function.

You will need to:
- Add a helper function (e.g., `stripHtmlTags`) near the top of the file.
- Replace `content.replace(/<[^>]+>/g, "")` with `stripHtmlTags(content)`.

No external dependencies are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
