### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete multi-character sanitization

### DIFF
--- a/Komo-live-chat/src/index.js
+++ b/Komo-live-chat/src/index.js
@@ -85,8 +85,11 @@
             },
 
             sendFriendMsg(message, author) {
-                const content = sanitizeHtml(getRandomMsg(message));
-                const length = content.replace(/<[^>]+>/g,"").length;
+                const content = sanitizeHtml(getRandomMsg(message), {
+                    allowedTags: [], // Remove all HTML tags
+                    allowedAttributes: {} // Remove all attributes
+                });
+                const length = content.length;
                 const isImg = /<img[^>]+>/.test(content);
                 const isTyping = length > 2 || isImg;
 


### PR DESCRIPTION
Potential fix for [https://github.com/ktwu01/komo520/security/code-scanning/9](https://github.com/ktwu01/komo520/security/code-scanning/9)

The best approach to fix this issue is to ensure that the sanitization process completely removes all potentially unsafe HTML tags, including `<script>` and similar malicious elements. One option is to rely solely on the `sanitizeHtml` library, as it is a well-tested library specifically designed for sanitization. If additional sanitization is required beyond `sanitizeHtml`, the replacement logic should be rewritten to repeatedly apply the regular expression until no unsafe text remains.

#### Steps to fix:
1. Configure `sanitizeHtml` to remove all unsafe HTML elements, including `<script>`.
2. Remove the redundant `replace` operation on line 89, as `sanitizeHtml` should handle this effectively.
3. Optionally, add a fallback mechanism to repeatedly apply sanitization logic in case of nested or complex malicious inputs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
